### PR TITLE
Add post format support

### DIFF
--- a/includes/Ability/Content_Abilities.php
+++ b/includes/Ability/Content_Abilities.php
@@ -132,6 +132,12 @@ class Content_Abilities {
 						'default'     => '',
 						'description' => 'Alt text for the featured image.',
 					),
+					'format'                => array(
+						'type'        => 'string',
+						'description' => __( 'Post format.', 'wp-pinch' ),
+						'enum'        => array( 'standard', 'aside', 'chat', 'gallery', 'link', 'image', 'quote', 'status', 'video', 'audio' ),
+						'default'     => 'standard',
+					),
 				),
 			),
 			array( 'type' => 'object' ),
@@ -159,6 +165,11 @@ class Content_Abilities {
 					'post_modified' => array(
 						'type'        => 'string',
 						'description' => 'Value from get-post modified field for optimistic locking. If provided and the post has changed since, the update is rejected.',
+					),
+					'format'        => array(
+						'type'        => 'string',
+						'description' => __( 'Post format.', 'wp-pinch' ),
+						'enum'        => array( 'standard', 'aside', 'chat', 'gallery', 'link', 'image', 'quote', 'status', 'video', 'audio' ),
 					),
 				),
 			),
@@ -341,6 +352,10 @@ class Content_Abilities {
 			return array( 'error' => $post_id->get_error_message() );
 		}
 
+		if ( ! empty( $input['format'] ) && 'standard' !== $input['format'] ) {
+			set_post_format( $post_id, $input['format'] );
+		}
+
 		update_post_meta( $post_id, '_wp_pinch_ai_generated', time() );
 
 		if ( ! empty( $input['tags'] ) ) {
@@ -438,6 +453,14 @@ class Content_Abilities {
 
 		if ( is_wp_error( $result ) ) {
 			return array( 'error' => $result->get_error_message() );
+		}
+
+		if ( ! empty( $input['format'] ) ) {
+			if ( 'standard' === $input['format'] ) {
+				set_post_format( $post_id, false );
+			} else {
+				set_post_format( $post_id, $input['format'] );
+			}
 		}
 
 		update_post_meta( $post_id, '_wp_pinch_ai_generated', time() );

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -387,6 +387,7 @@ class Abilities {
 			'title'    => $post->post_title,
 			'status'   => $post->post_status,
 			'type'     => $post->post_type,
+			'format'   => get_post_format( $post->ID ) ?: 'standard',
 			'date'     => $post->post_date,
 			'modified' => $post->post_modified,
 			'author'   => get_the_author_meta( 'display_name', (int) $post->post_author ),


### PR DESCRIPTION
## Summary

- Adds `format` parameter to `create-post` and `update-post` abilities
- Includes `format` field in `get-post` output (and all post listings via `format_post`)
- Uses standard WordPress `set_post_format()`/`get_post_format()` functions
- Format enum: standard, aside, chat, gallery, link, image, quote, status, video, audio

## Test plan

- [ ] Create post with format parameter set to 'aside' -- verify post has aside format
- [ ] Update existing post format from 'standard' to 'quote' -- verify format changed
- [ ] Get post -- verify format field appears in response
- [ ] Create post without format parameter -- verify defaults to 'standard'

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>